### PR TITLE
Remove Xcode warning forArmchair.swift:720:14

### DIFF
--- a/Source/Armchair.swift
+++ b/Source/Armchair.swift
@@ -717,7 +717,7 @@ public enum ArmchairKey: String, CustomStringConvertible {
 }
 
 open class ArmchairTrackingInfo: CustomStringConvertible {
-    open let info: Dictionary<ArmchairKey, AnyObject>
+    public let info: Dictionary<ArmchairKey, AnyObject>
     
     init(info: Dictionary<ArmchairKey, AnyObject>) {
         self.info = info


### PR DESCRIPTION
'let' properties are implicitly 'final'; use 'public' instead of 'open'